### PR TITLE
16 game stats

### DIFF
--- a/server/inc/action/AttackAction.h
+++ b/server/inc/action/AttackAction.h
@@ -7,9 +7,10 @@
 #include "Common.h"
 #include "GemPile.h"
 #include "Bomb.h"
-
 #include "Deposit.h"
+
 #include "Board.h"
+#include "Stats.h"
 
 class Unit;
 

--- a/server/inc/game/ReplayEncoder.h
+++ b/server/inc/game/ReplayEncoder.h
@@ -7,13 +7,16 @@ using json = nlohmann::ordered_json;
 #include "Logger.h"
 #include "Config.h"
 #include "Action.h"
+#include "Stats.h"
 #include "Core.h"
 
 #include <fstream>
 #include <unordered_map>
 #include <filesystem>
+#include <cstdlib>
 
-enum class death_reason_t {
+enum class death_reason_t
+{
 	NONE_SURVIVED,
 	CORE_DESTROYED,
 	DISCONNECTED,
@@ -24,13 +27,14 @@ enum class death_reason_t {
 	TIMEOUT_RANDOM
 };
 
-typedef struct team_data_s {
+typedef struct team_data_s
+{
 	unsigned int teamId;
 	std::string teamName;
 	bool connectedInitially = false;
 	death_reason_t deathReason = death_reason_t::DID_NOT_CONNECT;
 	unsigned int place = std::numeric_limits<unsigned int>::max(); // 0 = won
-}	team_data_t;
+} team_data_t;
 
 class ReplayEncoder
 {
@@ -38,19 +42,19 @@ public:
 	ReplayEncoder() : ticks_(json::object()), lastTickCount_(0) {}
 	~ReplayEncoder() = default;
 
-	static ReplayEncoder& instance();
+	static ReplayEncoder &instance();
 
 	void addTickState(json &state, unsigned long long tick, std::vector<std::pair<std::unique_ptr<Action>, Core *>> &actions);
 
 	void registerExpectedTeam(unsigned int teamId);
-	void setTeamName(unsigned int teamId, const std::string& teamName);
+	void setTeamName(unsigned int teamId, const std::string &teamName);
 	void markConnectedInitially(unsigned int teamId, bool connected);
 	void setDeathReason(unsigned int teamId, death_reason_t reason);
 	void setPlace(unsigned int teamId, unsigned int place);
 
 	bool wasConnectedInitially(unsigned int teamId) const;
 
-	void includeConfig(json& config);
+	void includeConfig(json &config);
 	json &getCustomData(void) { return customData_; }
 
 	void exportReplay() const;

--- a/server/inc/game/Stats.h
+++ b/server/inc/game/Stats.h
@@ -1,0 +1,51 @@
+#ifndef STATS_H
+#define STATS_H
+
+#include <unordered_map>
+#include <string>
+#include <string_view>
+#include "json.hpp"
+using json = nlohmann::ordered_json;
+
+namespace stat_keys
+{
+	inline constexpr std::string_view damage_total = "damage_total";
+	inline constexpr std::string_view damage_self = "damage_self";
+	inline constexpr std::string_view damage_opponent = "damage_opponent";
+
+	inline constexpr std::string_view damage_units = "damage_units";
+	inline constexpr std::string_view damage_cores = "damage_cores";
+	inline constexpr std::string_view damage_walls = "damage_walls";
+	inline constexpr std::string_view damage_deposits = "damage_deposits";
+
+	inline constexpr std::string_view units_spawned = "units_spawned";
+	inline constexpr std::string_view walls_spawned = "walls_spawned";
+	inline constexpr std::string_view bombs_spawned = "bombs_spawned";
+
+	inline constexpr std::string_view units_destroyed = "units_destroyed";
+	inline constexpr std::string_view cores_destroyed = "cores_destroyed";
+	inline constexpr std::string_view deposits_destroyed = "deposits_destroyed";
+	inline constexpr std::string_view gempiles_destroyed = "gempiles_destroyed"; // picked up
+	inline constexpr std::string_view walls_destroyed = "walls_destroyed";
+	inline constexpr std::string_view bombs_destroyed = "bombs_destroyed"; // explosions
+
+	inline constexpr std::string_view money_transferred = "money_transferred";
+	inline constexpr std::string_view tiles_traveled = "tiles_traveled";
+
+	inline constexpr std::string_view gems_gained = "gems_gained";
+
+	inline constexpr std::string_view actions_executed = "actions_executed";
+}
+
+class Stats
+{
+public:
+	static Stats &instance();
+	void inc(std::string_view key, uint64_t by = 1);
+	json toJson() const;
+
+private:
+	std::unordered_map<std::string, uint64_t> counters_;
+};
+
+#endif // STATS_H

--- a/server/inc/game/Stats.h
+++ b/server/inc/game/Stats.h
@@ -29,7 +29,7 @@ namespace stat_keys
 	inline constexpr std::string_view walls_destroyed = "walls_destroyed";
 	inline constexpr std::string_view bombs_destroyed = "bombs_destroyed"; // explosions
 
-	inline constexpr std::string_view money_transferred = "money_transferred";
+	inline constexpr std::string_view gems_transferred = "gems_transferred";
 	inline constexpr std::string_view tiles_traveled = "tiles_traveled";
 
 	inline constexpr std::string_view gems_gained = "gems_gained";

--- a/server/inc/object/Bomb.h
+++ b/server/inc/object/Bomb.h
@@ -5,21 +5,22 @@
 #include "Common.h"
 #include "Config.h"
 #include "Board.h"
+#include "Stats.h"
 
 class Bomb : public Object
 {
-	public:
-		Bomb();
-		Bomb(const Bomb &other)
-			: Object(other), countdown_(other.countdown_) {}
+public:
+	Bomb();
+	Bomb(const Bomb &other)
+		: Object(other), countdown_(other.countdown_) {}
 
-		void explode();
-		void tick(unsigned long long tickCount);
+	void explode();
+	void tick(unsigned long long tickCount);
 
-		unsigned int getCountdown() const { return countdown_; }
+	unsigned int getCountdown() const { return countdown_; }
 
-	private:
-		unsigned int countdown_ = 0; // Countdown for the bomb to explode
+private:
+	unsigned int countdown_ = 0; // Countdown for the bomb to explode
 };
 
 #endif // BOMB_H

--- a/server/src/action/AttackAction.cpp
+++ b/server/src/action/AttackAction.cpp
@@ -61,26 +61,48 @@ std::string AttackAction::execute(Core *core)
 	unit->resetActionCooldown();
 
 	// calculate attack damage depending on object type
+	unsigned int damage = 1;
 	if (obj->getType() == ObjectType::Unit)
 	{
-		obj->setHP(obj->getHP() - Config::game().units[unit->getUnitType()].damageUnit);
+		damage = Config::game().units[unit->getUnitType()].damageUnit;
+		obj->setHP(obj->getHP() - damage);
+
+		Stats::instance().inc(stat_keys::damage_units, damage);
+		if (((Unit *)obj)->getTeamId() != unit->getTeamId())
+			Stats::instance().inc(stat_keys::damage_opponent, damage);
+		else
+			Stats::instance().inc(stat_keys::damage_self, damage);
 	}
 	else if (obj->getType() == ObjectType::Core)
 	{
-		obj->setHP(obj->getHP() - Config::game().units[unit->getUnitType()].damageCore);
+		damage = Config::game().units[unit->getUnitType()].damageCore;
+		obj->setHP(obj->getHP() - damage);
+
+		Stats::instance().inc(stat_keys::damage_cores, damage);
+		if (((Core *)obj)->getTeamId() != unit->getTeamId())
+			Stats::instance().inc(stat_keys::damage_opponent, damage);
+		else
+			Stats::instance().inc(stat_keys::damage_self, damage);
 	}
 	else if (obj->getType() == ObjectType::Deposit)
 	{
-		obj->setHP(obj->getHP() - Config::game().units[unit->getUnitType()].damageDeposit);
-		if (obj->getHP() > 0)
-			return "";
-		unsigned int gems = ((Deposit *)obj)->getBalance();
-		Board::instance().removeObjectById(obj->getId());
-		Board::instance().addObject<GemPile>(GemPile(gems), target_pos_);
+		damage = Config::game().units[unit->getUnitType()].damageDeposit;
+		obj->setHP(obj->getHP() - damage);
+		if (obj->getHP() <= 0)
+		{
+			unsigned int gems = ((Deposit *)obj)->getBalance();
+			Board::instance().removeObjectById(obj->getId());
+			Board::instance().addObject<GemPile>(GemPile(gems), target_pos_);
+		}
+
+		Stats::instance().inc(stat_keys::damage_deposits, damage);
 	}
 	else if (obj->getType() == ObjectType::Wall)
 	{
-		obj->setHP(obj->getHP() - Config::game().units[unit->getUnitType()].damageWall);
+		damage = Config::game().units[unit->getUnitType()].damageWall;
+		obj->setHP(obj->getHP() - damage);
+
+		Stats::instance().inc(stat_keys::damage_walls, damage);
 	}
 	else if (obj->getType() == ObjectType::Bomb)
 	{
@@ -89,9 +111,16 @@ std::string AttackAction::execute(Core *core)
 	}
 	else if (obj->getType() == ObjectType::GemPile)
 	{
-		unit->setBalance(unit->getBalance() + static_cast<GemPile *>(obj)->getBalance());
+		unsigned int gems = static_cast<GemPile *>(obj)->getBalance();
+		unit->setBalance(unit->getBalance() + gems);
 		Board::instance().removeObjectById(obj->getId());
+
+		Stats::instance().inc(stat_keys::gems_gained, gems);
+		Stats::instance().inc(stat_keys::gempiles_destroyed, gems);
 	}
+
+	Stats::instance().inc(stat_keys::actions_executed);
+	Stats::instance().inc(stat_keys::damage_total, damage);
 
 	return "";
 }

--- a/server/src/action/AttackAction.cpp
+++ b/server/src/action/AttackAction.cpp
@@ -93,6 +93,8 @@ std::string AttackAction::execute(Core *core)
 			unsigned int gems = ((Deposit *)obj)->getBalance();
 			Board::instance().removeObjectById(obj->getId());
 			Board::instance().addObject<GemPile>(GemPile(gems), target_pos_);
+
+			Stats::instance().inc(stat_keys::deposits_destroyed, 1);
 		}
 
 		Stats::instance().inc(stat_keys::damage_deposits, damage);
@@ -116,7 +118,7 @@ std::string AttackAction::execute(Core *core)
 		Board::instance().removeObjectById(obj->getId());
 
 		Stats::instance().inc(stat_keys::gems_gained, gems);
-		Stats::instance().inc(stat_keys::gempiles_destroyed, gems);
+		Stats::instance().inc(stat_keys::gempiles_destroyed, 1);
 	}
 
 	Stats::instance().inc(stat_keys::actions_executed);

--- a/server/src/action/BuildAction.cpp
+++ b/server/src/action/BuildAction.cpp
@@ -65,6 +65,8 @@ std::string BuildAction::execute(Core *core)
 		builder->resetActionCooldown();
 		builder->setBalance(builder->getBalance() - Config::game().wallBuildCost);
 		Board::instance().addObject<Wall>(Wall(), position_);
+
+		Stats::instance().inc(stat_keys::walls_spawned);
 	}
 	else if (buildType == BuildType::BOMB)
 	{
@@ -73,7 +75,11 @@ std::string BuildAction::execute(Core *core)
 		builder->resetActionCooldown();
 		builder->setBalance(builder->getBalance() - Config::game().bombThrowCost);
 		Board::instance().addObject<Bomb>(Bomb(), position_);
+
+		Stats::instance().inc(stat_keys::bombs_spawned);
 	}
+
+	Stats::instance().inc(stat_keys::actions_executed);
 
 	return "";
 }

--- a/server/src/action/CreateAction.cpp
+++ b/server/src/action/CreateAction.cpp
@@ -44,5 +44,8 @@ std::string CreateAction::execute(Core *core)
 	Board::instance().addObject<Unit>(Unit(core->getTeamId(), unit_type_), closestEmptyPos);
 	core->setBalance(core->getBalance() - unitCost);
 
+	Stats::instance().inc(stat_keys::units_spawned);
+	Stats::instance().inc(stat_keys::actions_executed);
+
 	return "";
 }

--- a/server/src/action/MoveAction.cpp
+++ b/server/src/action/MoveAction.cpp
@@ -59,5 +59,8 @@ std::string MoveAction::execute(Core *core)
 	Board::instance().moveObjectById(unit->getId(), target_);
 	unit->resetActionCooldown();
 
+	Stats::instance().inc(stat_keys::tiles_traveled);
+	Stats::instance().inc(stat_keys::actions_executed);
+
 	return "";
 }

--- a/server/src/action/TransferGemsAction.cpp
+++ b/server/src/action/TransferGemsAction.cpp
@@ -59,6 +59,9 @@ std::string TransferGemsAction::dropMoney(Core *core, Object *srcObj)
 
 	Board::instance().addObject<GemPile>(GemPile(amount_), target_);
 
+	Stats::instance().inc(stat_keys::actions_executed);
+	Stats::instance().inc(stat_keys::gems_transferred, amount_);
+
 	return "";
 }
 
@@ -129,6 +132,9 @@ std::string TransferGemsAction::execute(Core *core)
 		Unit *dstUnit = (Unit *)dstObj;
 		dstUnit->setBalance(dstUnit->getBalance() + amount_);
 	}
+
+	Stats::instance().inc(stat_keys::actions_executed);
+	Stats::instance().inc(stat_keys::gems_transferred, amount_);
 
 	return "";
 }

--- a/server/src/game/Game.cpp
+++ b/server/src/game/Game.cpp
@@ -167,9 +167,6 @@ void Game::tick(unsigned long long tick, std::vector<std::pair<std::unique_ptr<A
 			case ObjectType::Wall:
 				Stats::instance().inc(stat_keys::walls_destroyed);
 				break;
-			case ObjectType::Deposit:
-				Stats::instance().inc(stat_keys::deposits_destroyed);
-				break;
 			case ObjectType::Core:
 				Stats::instance().inc(stat_keys::cores_destroyed);
 				break;

--- a/server/src/game/ReplayEncoder.cpp
+++ b/server/src/game/ReplayEncoder.cpp
@@ -1,9 +1,12 @@
 #include "ReplayEncoder.h"
-#include <cstdlib>
 
 #define REPLAY_VERSION std::string("1.1.1")
 
-ReplayEncoder& ReplayEncoder::instance() { static ReplayEncoder inst; return inst; }
+ReplayEncoder &ReplayEncoder::instance()
+{
+	static ReplayEncoder inst;
+	return inst;
+}
 
 void ReplayEncoder::addTickState(json &state, unsigned long long tick, std::vector<std::pair<std::unique_ptr<Action>, Core *>> &actions)
 {
@@ -23,9 +26,10 @@ void ReplayEncoder::addTickState(json &state, unsigned long long tick, std::vect
 
 void ReplayEncoder::registerExpectedTeam(unsigned int teamId)
 {
-	if (!teamData_.count(teamId)) teamData_[teamId].teamId = teamId;
+	if (!teamData_.count(teamId))
+		teamData_[teamId].teamId = teamId;
 }
-void ReplayEncoder::setTeamName(unsigned int teamId, const std::string& teamName)
+void ReplayEncoder::setTeamName(unsigned int teamId, const std::string &teamName)
 {
 	registerExpectedTeam(teamId);
 	teamData_[teamId].teamName = teamName;
@@ -47,7 +51,8 @@ void ReplayEncoder::setPlace(unsigned int teamId, unsigned int place)
 	teamData_[teamId].place = place;
 }
 
-bool ReplayEncoder::wasConnectedInitially(unsigned int teamId) const {
+bool ReplayEncoder::wasConnectedInitially(unsigned int teamId) const
+{
 	auto it = teamData_.find(teamId);
 	return it != teamData_.end() && it->second.connectedInitially;
 }
@@ -92,9 +97,9 @@ json ReplayEncoder::encodeMiscSection() const
 	json miscSection;
 
 	json players = json::array();
-	for (const auto& kv : teamData_)
+	for (const auto &kv : teamData_)
 	{
-		const auto& p = kv.second;
+		const auto &p = kv.second;
 		json pj;
 		pj["id"] = p.teamId;
 		pj["name"] = p.teamName;
@@ -111,6 +116,8 @@ json ReplayEncoder::encodeMiscSection() const
 	const char *gameId = std::getenv("GAME_ID");
 	miscSection["game_id"] = gameId ? std::string(gameId) : "";
 
+	miscSection["stats"] = Stats::instance().toJson();
+
 	return miscSection;
 }
 
@@ -124,7 +131,7 @@ void ReplayEncoder::exportReplay() const
 
 	json replayData;
 	replayData["misc"] = encodeMiscSection();
-	for (auto& kv : customData_.items())
+	for (auto &kv : customData_.items())
 		replayData["misc"][kv.key()] = kv.value();
 	replayData["ticks"] = !ticks_.empty() ? ticks_ : json::array();
 	replayData["config"] = config_;

--- a/server/src/game/Stats.cpp
+++ b/server/src/game/Stats.cpp
@@ -1,0 +1,20 @@
+#include "Stats.h"
+
+Stats &Stats::instance()
+{
+	static Stats s;
+	return s;
+}
+
+void Stats::inc(std::string_view key, uint64_t by)
+{
+	counters_[std::string(key)] += by;
+}
+
+json Stats::toJson() const
+{
+	json j = json::object();
+	for (const auto &kv : counters_)
+		j[kv.first] = kv.second;
+	return j;
+}

--- a/server/src/object/Bomb.cpp
+++ b/server/src/object/Bomb.cpp
@@ -44,6 +44,8 @@ void Bomb::explode()
 		obj->setHP(obj->getHP() - Config::game().bombDamage);
 	}
 	Board::instance().removeObjectById(this->getId());
+
+	Stats::instance().inc(stat_keys::bombs_destroyed);
 }
 
 void Bomb::tick(unsigned long long tickCount)


### PR DESCRIPTION
Stored in misc section so it's sent via rabbitMQ so @Peu77 can easily read it out later. In the replay they look like this:

<img width="316" height="359" alt="Screenshot 2025-08-27 at 11 30 48" src="https://github.com/user-attachments/assets/12c7defd-276e-48a3-9553-2c51e0e4f7e2" />

Decided to go for unified namings over object-specific verbs, e.g. bombs destroyed = count of bombs that exploded.

I think we should highlight mainly stuff like "damage-self" and "cores-destroyed" and "units-spawned" on the website but make all of them accessible.

Cores destroyed is a stat because theoretically eventually three teams might play a game against each other.