### PR TITLE
71 improved seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 replay_latest.json
-visualizer/public/replays/replay_latest.json

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SERVER_EXECUTABLE := server
 # Configs
 CONFIG_FOLDER := my-core-bot/configs
 CONFIG_SERVER_FILE := $(CONFIG_FOLDER)/server-config.json
-CONFIG_GAME_FILE := $(CONFIG_FOLDER)/soft-config.json
+CONFIG_GAME_FILE := $(CONFIG_FOLDER)/hard-config.json
 
 DATA_FOLDER_PATH := server/data
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -40,10 +40,12 @@ FetchContent_MakeAvailable(json_schema_validator)
 set(XXHASH_VERSION v0.8.2)
 set(XXHASH_INC "${CMAKE_BINARY_DIR}/xxhash/include")
 file(MAKE_DIRECTORY "${XXHASH_INC}")
-file(DOWNLOAD
+if(NOT EXISTS "${XXHASH_INC}/xxhash.h")
+	file(DOWNLOAD
 		"https://raw.githubusercontent.com/Cyan4973/xxHash/${XXHASH_VERSION}/xxhash.h"
 		"${XXHASH_INC}/xxhash.h"
 		TLS_VERIFY ON)
+endif()
 add_library(xxhash INTERFACE)
 
 set(CMAKE_CXX_FLAGS_PROD "-O3 -DNDEBUG")

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(server CXX)
+project(server C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -37,6 +37,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(json_schema_validator)
 
+set(XXHASH_VERSION v0.8.2)
+set(XXHASH_INC "${CMAKE_BINARY_DIR}/xxhash/include")
+file(MAKE_DIRECTORY "${XXHASH_INC}")
+file(DOWNLOAD
+		"https://raw.githubusercontent.com/Cyan4973/xxHash/${XXHASH_VERSION}/xxhash.h"
+		"${XXHASH_INC}/xxhash.h"
+		TLS_VERIFY ON)
+add_library(xxhash INTERFACE)
+
 set(CMAKE_CXX_FLAGS_PROD "-O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_PROD   "-O3 -DNDEBUG")
 set(CMAKE_EXE_LINKER_FLAGS_PROD "")
@@ -64,8 +73,9 @@ target_include_directories(server PRIVATE ${ALL_INC_DIRS})
 target_include_directories(server PRIVATE
 	"${CMAKE_BINARY_DIR}/nlohmann_json/include/nlohmann"
 	"${CMAKE_BINARY_DIR}/_deps/json_schema_validator-src/src/nlohmann"
+	"${CMAKE_BINARY_DIR}/xxhash/include"
 )
 
 target_compile_options(server PRIVATE -Wall -Wextra -Werror)
 
-target_link_libraries(server PRIVATE nlohmann_json nlohmann_json_schema_validator)
+target_link_libraries(server PRIVATE nlohmann_json nlohmann_json_schema_validator xxhash)

--- a/server/data/config-schemas/game-config.schema.json
+++ b/server/data/config-schemas/game-config.schema.json
@@ -5,7 +5,6 @@
 	"additionalProperties": false,
 	"required": [
 		"gridSize",
-		"seed",
 		"idleIncome",
 		"idleIncomeTimeOut",
 		"depositHp",
@@ -33,9 +32,7 @@
 			"maximum": 200
 		},
 		"seed": {
-			"type": "integer",
-			"minimum": 1,
-			"maximum": 10000000
+			"type": "string"
 		},
 		"idleIncome": {
 			"type": "integer",

--- a/server/inc/config/Config.h
+++ b/server/inc/config/Config.h
@@ -21,7 +21,9 @@ struct GameConfig
 
 	unsigned int gridSize;
 
-	unsigned int seed = std::chrono::system_clock::now().time_since_epoch().count();
+	uint64_t seed;
+	std::string seedString = "";
+	bool usedRandomSeed = false;
 
 	unsigned int idleIncome;		// idle income per tick
 	unsigned int idleIncomeTimeOut; // idle income duration in ticks

--- a/server/inc/config/worldgen/EmptyWorldGenerator.h
+++ b/server/inc/config/worldgen/EmptyWorldGenerator.h
@@ -8,7 +8,7 @@ class EmptyWorldGenerator : public WorldGenerator
 	public:
 		EmptyWorldGenerator();
 
-		void generateWorld(unsigned int seed);
+		void generateWorld(uint64_t seed);
 };
 
 #endif // EMPTY_WORLD_GENERATOR_H

--- a/server/inc/config/worldgen/HardcodedWorldGenerator.h
+++ b/server/inc/config/worldgen/HardcodedWorldGenerator.h
@@ -17,7 +17,7 @@ class HardcodedWorldGenerator : public WorldGenerator
 	public:
 		HardcodedWorldGenerator();
 
-		void generateWorld(unsigned int seed);
+		void generateWorld(uint64_t seed);
 };
 
 #endif // HARDCODED_WORLD_GENERATOR_H

--- a/server/inc/config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.h
+++ b/server/inc/config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.h
@@ -32,7 +32,7 @@ class JigsawWorldGenerator : public WorldGenerator {
 	public:
 		JigsawWorldGenerator();
 
-		void generateWorld(unsigned int seed);
+		void generateWorld(uint64_t seed);
 
 	private:
 		std::vector<MapTemplate> templates_;

--- a/server/inc/config/worldgen/SparseWorldGenerator.h
+++ b/server/inc/config/worldgen/SparseWorldGenerator.h
@@ -17,7 +17,7 @@ class SparseWorldGenerator : public WorldGenerator
 	public:
 		SparseWorldGenerator();
 
-		void generateWorld(unsigned int seed);
+		void generateWorld(uint64_t seed);
 
 	private:
 		std::mt19937_64 eng_{};

--- a/server/inc/config/worldgen/WorldGenerator.h
+++ b/server/inc/config/worldgen/WorldGenerator.h
@@ -12,7 +12,7 @@ class WorldGenerator
 		WorldGenerator() = default;
 		virtual ~WorldGenerator() = default;
 		
-		virtual void generateWorld(unsigned int seed) = 0;
+		virtual void generateWorld(uint64_t seed) = 0;
 };
 
 #endif // WORLD_GENERATOR_H

--- a/server/inc/utils/Utils.h
+++ b/server/inc/utils/Utils.h
@@ -13,6 +13,8 @@
 
 Position findFirstEmptyGridCell(Position startPos);
 
+std::string random_base32_seed();
+
 template <typename T>
 void shuffle_vector(std::vector<T> & vec)
 {

--- a/server/src/config/Config.cpp
+++ b/server/src/config/Config.cpp
@@ -12,7 +12,9 @@ std::string Config::dataFolderPath = "";
 #include "HardcodedWorldGenerator.h"
 #include "EmptyWorldGenerator.h"
 
+#define XXH_INLINE_ALL
 #include "xxhash.h"
+
 #include "Utils.h"
 
 static void validate_or_die(const json& instance, const std::string& schema_name) {
@@ -76,7 +78,7 @@ static GameConfig parseGameConfig()
 	config.gridSize = j.value("gridSize", 25);
 
 	config.seedString = j.value("seed", "");
-	if (config.seedString.isEmpty())
+	if (config.seedString.empty())
 	{
 		config.seedString = random_base32_seed();
 		config.usedRandomSeed = true;

--- a/server/src/config/Config.cpp
+++ b/server/src/config/Config.cpp
@@ -12,6 +12,9 @@ std::string Config::dataFolderPath = "";
 #include "HardcodedWorldGenerator.h"
 #include "EmptyWorldGenerator.h"
 
+#include "xxhash.h"
+#include "Utils.h"
+
 static void validate_or_die(const json& instance, const std::string& schema_name) {
 	std::string fullName = Config::getDataFolderPath() + "/config-schemas/" + schema_name;
 	std::ifstream s(fullName);
@@ -71,7 +74,15 @@ static GameConfig parseGameConfig()
 	validate_or_die(j, "game-config.schema.json");
 
 	config.gridSize = j.value("gridSize", 25);
-	config.seed = j.value("seed", 1);
+
+	config.seedString = j.value("seed", "");
+	if (config.seedString.isEmpty())
+	{
+		config.seedString = random_base32_seed();
+		config.usedRandomSeed = true;
+	}
+	config.seed = XXH64(config.seedString.data(), config.seedString.size(), 0);
+
 	config.idleIncome = j.value("idleIncome", 1);
 	config.idleIncomeTimeOut = j.value("idleIncomeTimeOut", 600);
 	config.depositHp = j.value("depositHp", 50);

--- a/server/src/config/worldgen/EmptyWorldGenerator.cpp
+++ b/server/src/config/worldgen/EmptyWorldGenerator.cpp
@@ -4,7 +4,7 @@ EmptyWorldGenerator::EmptyWorldGenerator()
 {
 }
 
-void EmptyWorldGenerator::generateWorld(unsigned int seed)
+void EmptyWorldGenerator::generateWorld(uint64_t seed)
 {
 	(void)seed;
 }

--- a/server/src/config/worldgen/HardcodedWorldGenerator.cpp
+++ b/server/src/config/worldgen/HardcodedWorldGenerator.cpp
@@ -4,7 +4,7 @@ HardcodedWorldGenerator::HardcodedWorldGenerator()
 {
 }
 
-void HardcodedWorldGenerator::generateWorld(unsigned int seed)
+void HardcodedWorldGenerator::generateWorld(uint64_t seed)
 {
 	(void)seed;
 

--- a/server/src/config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.cpp
+++ b/server/src/config/worldgen/JigsawWorldGenerator/JigsawWorldGenerator.cpp
@@ -414,7 +414,7 @@ void JigsawWorldGenerator::mirrorWorld()
 
 
 
-void JigsawWorldGenerator::generateWorld(unsigned int seed)
+void JigsawWorldGenerator::generateWorld(uint64_t seed)
 {
 	eng_ = std::mt19937_64(seed);
 

--- a/server/src/config/worldgen/SparseWorldGenerator.cpp
+++ b/server/src/config/worldgen/SparseWorldGenerator.cpp
@@ -23,7 +23,7 @@ static bool positionHasNeighbours(const Position &pos, int N)
 	return false;
 }
 
-void SparseWorldGenerator::generateWorld(unsigned int seed)
+void SparseWorldGenerator::generateWorld(uint64_t seed)
 {
 	eng_.seed(seed);
 

--- a/server/src/game/Game.cpp
+++ b/server/src/game/Game.cpp
@@ -11,7 +11,7 @@ Game::Game(std::vector<unsigned int> team_ids)
 		Logger::Log("Generating world with random seed as no seed was provided.");
 	Logger::Log("Generating world with seed \"" + Config::game().seedString + "\". (hash: " + std::to_string(Config::game().seed) + ")");
 	Config::game().worldGenerator->generateWorld(Config::game().seed);
-	ReplayEncoder::instance().getCustomData()["worldGeneratorSeed"] = Config::game().seed;
+	ReplayEncoder::instance().getCustomData()["worldGeneratorSeed"] = Config::game().seedString;
 
 	Logger::Log("Game created with " + std::to_string(team_ids.size()) + " teams.");
 }

--- a/server/src/game/Game.cpp
+++ b/server/src/game/Game.cpp
@@ -9,7 +9,7 @@ Game::Game(std::vector<unsigned int> team_ids)
 
 	if (Config::game().usedRandomSeed)
 		Logger::Log("Generating world with random seed as no seed was provided.");
-	Logger::Log("Generating world with seed \"" + std::to_string(Config::game().seed) + "\". (hash: " + std::to_string(Config::game().seed) + ")");
+	Logger::Log("Generating world with seed \"" + Config::game().seedString + "\". (hash: " + std::to_string(Config::game().seed) + ")");
 	Config::game().worldGenerator->generateWorld(Config::game().seed);
 	ReplayEncoder::instance().getCustomData()["worldGeneratorSeed"] = Config::game().seed;
 

--- a/server/src/game/Game.cpp
+++ b/server/src/game/Game.cpp
@@ -7,18 +7,11 @@ Game::Game(std::vector<unsigned int> team_ids)
 	for (unsigned int i = 0; i < team_ids.size(); ++i)
 		Board::instance().addObject<Core>(Core(team_ids[i]), Config::getCorePosition(i), true);
 
-	unsigned int seed = Config::game().seed;
-	if (seed == 1)
-	{
-		std::random_device rd;
-		uint64_t time_part = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-		std::seed_seq seq{rd(), uint32_t(time_part), uint32_t(time_part >> 32)};
-		seq.generate(&seed, &seed + 1);
-		seed %= 10000000; // make seed adhere to config schema limits
-	}
-	Logger::Log("Generating world with seed \"" + std::to_string(seed) + "\".");
-	Config::game().worldGenerator->generateWorld(seed);
-	ReplayEncoder::instance().getCustomData()["worldGeneratorSeed"] = seed;
+	if (Config::game().usedRandomSeed)
+		Logger::Log("Generating world with random seed as no seed was provided.");
+	Logger::Log("Generating world with seed \"" + std::to_string(Config::game().seed) + "\". (hash: " + std::to_string(Config::game().seed) + ")");
+	Config::game().worldGenerator->generateWorld(Config::game().seed);
+	ReplayEncoder::instance().getCustomData()["worldGeneratorSeed"] = Config::game().seed;
 
 	Logger::Log("Game created with " + std::to_string(team_ids.size()) + " teams.");
 }

--- a/server/src/utils/random_string.cpp
+++ b/server/src/utils/random_string.cpp
@@ -4,7 +4,8 @@
 std::string random_base32_seed()
 {
 	static constexpr char A[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-	uint64_t r = (static_cast<uint64_t>(std::random_device{}()) << 32) | std::random_device{}();
+	std::random_device rd;
+	uint64_t r = (static_cast<uint64_t>(rd()) << 32) | rd();
 	std::string s; s.resize(13);
 	for (int i = 0; i < 13; ++i) { s[i] = A[r & 31u]; r >>= 5; }
 	return s;

--- a/server/src/utils/random_string.cpp
+++ b/server/src/utils/random_string.cpp
@@ -1,0 +1,11 @@
+#include <random>
+#include <cstdint>
+
+std::string random_base32_seed()
+{
+	static constexpr char A[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+	uint64_t r = (static_cast<uint64_t>(std::random_device{}()) << 32) | std::random_device{}();
+	std::string s; s.resize(13);
+	for (int i = 0; i < 13; ++i) { s[i] = A[r & 31u]; r >>= 5; }
+	return s;
+}


### PR DESCRIPTION
Works pretty well I believe. You can specify any string of any length in the config without impacting the final entropy in the world generation. (e.g. worlds generated with seeds "1" and "2" are statistically no more or less different than "3" and "hippopotamus20j9sjdfojsdf20". That's good. It's like Minecraft also seems to do it.

Leave seed field empty for random seed. We will then first generate a human-readable random string, and then we'll hash that.

For a consistent hashing algorithm that doesn't change on different OS C implementations, I used an external lib, [xxHash](https://xxhash.com/). Please note that including the xxhash header inlines the fully library, which, with a solid 7000 lines, could make the server slower and bloat the binary if we include it in a bunch of places. We should probably refrain from that, right now it's only included in Config.cpp.

@4n4k1n Since you're probably the one taking over primary development of the server and client lib in a few weeks, I figured I'd start adding you as a reviewer in PRs. Please have a look and lemme know what you think.