### PR TITLE
Same tick two core deaths bug

### DIFF
--- a/server/src/game/Game.cpp
+++ b/server/src/game/Game.cpp
@@ -229,14 +229,18 @@ void Game::tick(unsigned long long tick, std::vector<std::pair<std::unique_ptr<A
 		if (obj.getType() == ObjectType::Core && obj.getHP() <= 0)
 			removeTeamIds.push_back(static_cast<Core &>(obj).getTeamId());
 	}
-	for (unsigned tid : removeTeamIds)
+	shuffle_vector(removeTeamIds);
+	for (int i = 0; i < (int)removeTeamIds.size(); i++)
 	{
+		unsigned int tid = removeTeamIds[i];
+
 		for (auto it = bridges_.begin(); it != bridges_.end(); ++it)
 		{
 			if ((*it)->getTeamId() == tid)
 			{
 				ReplayEncoder::instance().setDeathReason(tid, death_reason_t::CORE_DESTROYED);
 				unsigned int place = Board::instance().getCoreCount();
+				if (removeTeamIds.size() > 1) place += i; // if multiple died at once, place them randomly
 				ReplayEncoder::instance().setPlace(tid, place);
 				if (place == 0)
 				{


### PR DESCRIPTION
Just happened in the tournament, when both teams were named YOURTEAMNAMEHERE there was no second line specifying who lost. That isn't fixed by this PR, but the fact that there wasn't a second line is. The replay file saved both users as being place 0, therefore winners. This was because we calculate the place based on how many cores are still left after the death, but that doesn't work here if two died. The website always needs a clear winner and loser, ties are not allowed. So with this setup it is entirely random who wins or dies we save things into the replay file correctly and the visualizer displays it correctly. This issue showed itself in the visualizer but the problem originated in the server.

Before:

<img width="787" height="233" alt="Screenshot 2025-09-26 at 14 04 06" src="https://github.com/user-attachments/assets/c434e26f-36af-46c9-8512-ec25aa51c221" />

After:

<img width="784" height="236" alt="Screenshot 2025-09-26 at 14 02 51" src="https://github.com/user-attachments/assets/07f1f8f0-e2c0-40b0-b5bf-477edbd89e31" />

Very easy to reproduce by having the default my-core-bot play against itself as it doesn't use randomness.