### PR TITLE
lighter metric bars for light team

### DIFF
--- a/visualizer/src/ts/renderer/objectRenderer.ts
+++ b/visualizer/src/ts/renderer/objectRenderer.ts
@@ -106,8 +106,8 @@ export function initializeTeamMapping(): void {
 	const leftCore = cores[0];
 	const rightCore = cores[1];
 
-	if (leftCore !== undefined) teamIdMapping.set(leftCore.teamId, 1);
-	if (rightCore !== undefined) teamIdMapping.set(rightCore.teamId, 0);
+	if (leftCore !== undefined && leftCore.teamId !== undefined) teamIdMapping.set(leftCore.teamId, 1);
+	if (rightCore !== undefined && rightCore.teamId !== undefined) teamIdMapping.set(rightCore.teamId, 0);
 }
 
 function getTeamIndex(teamId: number | undefined): AssetTeam {

--- a/visualizer/src/ts/renderer/objectRenderer.ts
+++ b/visualizer/src/ts/renderer/objectRenderer.ts
@@ -106,12 +106,8 @@ export function initializeTeamMapping(): void {
 	const leftCore = cores[0];
 	const rightCore = cores[1];
 
-	const flip = Math.random() < 0.5;
-	const teamForLight = flip ? leftCore.teamId : rightCore.teamId;
-	const teamForDark = flip ? rightCore.teamId : leftCore.teamId;
-
-	if (teamForLight !== undefined) teamIdMapping.set(teamForLight, 1);
-	if (teamForDark !== undefined) teamIdMapping.set(teamForDark, 0);
+	if (leftCore !== undefined) teamIdMapping.set(leftCore.teamId, 1);
+	if (rightCore !== undefined) teamIdMapping.set(rightCore.teamId, 0);
 }
 
 function getTeamIndex(teamId: number | undefined): AssetTeam {
@@ -162,14 +158,21 @@ function drawObject(
 	scaleFactor: number = 1,
 	metricBars: BarDrawingInstructions[],
 ): void {
-	for (const bar of metricBars) {
-		const color =
-			bar.key === "hp"
+	const teamIndex = getTeamIndex(obj.teamId);
+
+	// Color mixing helper (light team gets lighter metric bars)
+	const colorFor = (key: string): string => {
+		const base =
+			key === "hp"
 				? "var(--hp-color)"
-				: bar.key === "gems"
+				: key === "gems"
 					? "var(--gems-color)"
 					: "var(--cooldown-color)";
+		return teamIndex === 1 ? `color-mix(in srgb, ${base} 55%, white)` : base;
+	};
 
+	for (const bar of metricBars) {
+		const color = colorFor(bar.key);
 		const bg = document.createElementNS(svgNS, "rect");
 		bg.setAttribute("x", xOffset.toString());
 		bg.setAttribute("y", bar.topBorder.toString());


### PR DESCRIPTION
just a little help for improved visual distinction

also, i removed the logic to randomly switch the assignment of the solid and outline teams, now the outline team is always in the top left. I think this is better, you'll eventually just internalize which fill state is on what side of the board.

<img width="663" height="597" alt="Screenshot 2025-09-26 at 14 27 09" src="https://github.com/user-attachments/assets/10b2f283-615c-42f5-838b-0cdefb7c7aef" />
