### PR TITLE
added variables for bots in Makefiles

### DIFF
--- a/bots/hardcore/Makefile
+++ b/bots/hardcore/Makefile
@@ -53,7 +53,7 @@ stop:
 update: stop-devcontainer remove-devcontainer
 	@docker compose --project-directory=./.devcontainer pull
 
-.PHONY: run debug battle clean fclean re stop update $(PLAYER1_BOT) $(PLAYER2_BOT)
+.PHONY: run clean fclean re stop update $(PLAYER1_BOT) $(PLAYER2_BOT)
 
 
 # Devpod CLI executable

--- a/bots/hardcore/Makefile
+++ b/bots/hardcore/Makefile
@@ -1,16 +1,25 @@
 CORE_DIR = /core
-TARGET = my-core-bot/bot
 
 PLAYER1_ID := 42
 PLAYER2_ID := 43
 
-run: stop check_update_configs build build-gridmaster
+PLAYER1_BOT := my-core-bot/bot
+PLAYER2_BOT := gridmaster/gridmaster
+
+PLAYER1_DIR = $(patsubst %/,%,$(dir $(PLAYER1_BOT)))
+PLAYER2_DIR = $(patsubst %/,%,$(dir $(PLAYER2_BOT)))
+
+PLAYER1_BOT_NAME = $(notdir $(PLAYER1_BOT))
+PLAYER2_BOT_NAME = $(notdir $(PLAYER2_BOT))
+
+
+run: stop check_update_configs $(PLAYER1_BOT) $(PLAYER2_BOT)
 	@echo ""
 	@echo "$(COLOR_INFO)🎮 Game Visualizer is running at: localhost:4000 $(COLOR_RESET)"
 	@echo ""
 	$(CORE_DIR)/server /workspace/configs/server.config.json /workspace/configs/game.config.json $(CORE_DIR)/data $(PLAYER1_ID) $(PLAYER2_ID) > /dev/null &
-	./gridmaster/gridmaster $(PLAYER1_ID) > /dev/null &
-	./$(TARGET) $(PLAYER2_ID)
+	./$(PLAYER1_BOT) $(PLAYER1_ID) > /dev/null &
+	./$(PLAYER2_BOT) $(PLAYER2_ID)
 	@echo ""
 	@echo "$(COLOR_INFO)🎮 Game Visualizer is running at: localhost:4000 $(COLOR_RESET)"
 	@echo ""
@@ -19,31 +28,32 @@ check_update_configs:
 	chmod +x scripts/check_update_configs.sh
 	-./scripts/check_update_configs.sh
 
-build:
-	make -C my-core-bot
+$(PLAYER1_BOT):
+	make -C $(PLAYER1_DIR)
 
-build-gridmaster:
-	make -C gridmaster
+$(PLAYER2_BOT):
+	make -C $(PLAYER2_DIR)
+
 
 clean: stop
-	make -C gridmaster clean
-	make -C my-core-bot clean
+	make -C $(PLAYER2_DIR) clean
+	make -C $(PLAYER1_DIR) clean
 
 fclean: clean
-	make -C gridmaster fclean
-	make -C my-core-bot fclean
+	make -C $(PLAYER2_DIR) fclean
+	make -C $(PLAYER1_DIR) fclean
 
 re: fclean run
 
 stop:
 	@pkill server > /dev/null || true &
-	@pkill bot > /dev/null || true &
-	@pkill gridmaster > /dev/null || true
+	@pkill $(PLAYER1_BOT_NAME) > /dev/null || true &
+	@pkill $(PLAYER2_BOT_NAME) > /dev/null || true
 
 update: stop-devcontainer remove-devcontainer
 	@docker compose --project-directory=./.devcontainer pull
 
-.PHONY: run debug battle $(TARGET) clean fclean re stop update build-gridmaster build
+.PHONY: run debug battle clean fclean re stop update $(PLAYER1_BOT) $(PLAYER2_BOT)
 
 
 # Devpod CLI executable

--- a/bots/softcore/Makefile
+++ b/bots/softcore/Makefile
@@ -1,16 +1,25 @@
 CORE_DIR = /core
-TARGET = my-core-bot/bot
 
 PLAYER1_ID := 42
 PLAYER2_ID := 43
 
-run: stop check_update_configs build build-gridmaster
+PLAYER1_BOT := my-core-bot/bot
+PLAYER2_BOT := gridmaster/gridmaster
+
+PLAYER1_DIR = $(patsubst %/,%,$(dir $(PLAYER1_BOT)))
+PLAYER2_DIR = $(patsubst %/,%,$(dir $(PLAYER2_BOT)))
+
+PLAYER1_BOT_NAME = $(notdir $(PLAYER1_BOT))
+PLAYER2_BOT_NAME = $(notdir $(PLAYER2_BOT))
+
+
+run: stop check_update_configs $(PLAYER1_BOT) $(PLAYER2_BOT)
 	@echo ""
 	@echo "$(COLOR_INFO)🎮 Game Visualizer is running at: localhost:4000 $(COLOR_RESET)"
 	@echo ""
 	$(CORE_DIR)/server /workspace/configs/server.config.json /workspace/configs/game.config.json $(CORE_DIR)/data $(PLAYER1_ID) $(PLAYER2_ID) > /dev/null &
-	./gridmaster/gridmaster $(PLAYER1_ID) > /dev/null &
-	./$(TARGET) $(PLAYER2_ID)
+	./$(PLAYER1_BOT) $(PLAYER1_ID) > /dev/null &
+	./$(PLAYER2_BOT) $(PLAYER2_ID)
 	@echo ""
 	@echo "$(COLOR_INFO)🎮 Game Visualizer is running at: localhost:4000 $(COLOR_RESET)"
 	@echo ""
@@ -19,31 +28,32 @@ check_update_configs:
 	chmod +x scripts/check_update_configs.sh
 	-./scripts/check_update_configs.sh
 
-build:
-	make -C my-core-bot
+$(PLAYER1_BOT):
+	make -C $(PLAYER1_DIR)
 
-build-gridmaster:
-	make -C gridmaster
+$(PLAYER2_BOT):
+	make -C $(PLAYER2_DIR)
+
 
 clean: stop
-	make -C gridmaster clean
-	make -C my-core-bot clean
+	make -C $(PLAYER2_DIR) clean
+	make -C $(PLAYER1_DIR) clean
 
 fclean: clean
-	make -C gridmaster fclean
-	make -C my-core-bot fclean
+	make -C $(PLAYER2_DIR) fclean
+	make -C $(PLAYER1_DIR) fclean
 
 re: fclean run
 
 stop:
 	@pkill server > /dev/null || true &
-	@pkill bot > /dev/null || true &
-	@pkill gridmaster > /dev/null || true
+	@pkill $(PLAYER1_BOT_NAME) > /dev/null || true &
+	@pkill $(PLAYER2_BOT_NAME) > /dev/null || true
 
 update: stop-devcontainer remove-devcontainer
 	@docker compose --project-directory=./.devcontainer pull
 
-.PHONY: run debug battle $(TARGET) clean fclean re stop update build-gridmaster build
+.PHONY: run debug battle clean fclean re stop update $(PLAYER1_BOT) $(PLAYER2_BOT)
 
 
 # Devpod CLI executable

--- a/wiki/documentation/playing_against_others.md
+++ b/wiki/documentation/playing_against_others.md
@@ -1,4 +1,4 @@
-## Locally
+## Locally with executables
 
 Have the person you want to play against send them their executable. In their cloned git repo, it will be created under `my-core-bot/bot`.
 
@@ -9,6 +9,20 @@ Have the person you want to play against send them their executable. In their cl
 ```
 
 Running the following code will start a game of the player 1 executable against the player 2 executable.
+
+### Locally with source files
+
+Inside the devcontainer`/workspace` you can run your bot against gridmaster with `make`.
+Ore you can run other bots with specifying `PLAYER1_BOT` and/or `PLAYER2_BOT`.
+To test some different strategies just copy the complete folder.
+Be aware at the end the bot in my-core-bot gets used in the public fights.
+
+```bash
+make PLAYER1_BOT=my-core-bot/bot PLAYER2_BOT=gridmaster/gridmaster
+```
+
+Running the following code will call both Makefiles, build both bots and starts the game.
+
 
 ## Online
 


### PR DESCRIPTION
Closes #144 change Makefiles of Hardcore and Softcore to build simpler
 - added PLAYER_BOT, PLAYER_BOT_SRC, PLAYER_BOT_OBJ variables
 - updated wiki documentation for playing against others locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run matches locally using two configurable bots (build-and-run from source) with per-bot build targets and dynamic invocation.

* **Documentation**
  * Added "Locally with source files" section and example command showing how to build and start both bots; retained executable-based instructions.

* **Chores**
  * Simplified build/run/stop/clean flows to operate per-bot and terminate bots by configurable names; updated phony targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->