### PR TITLE
[visualizer] dynamic visualizer speed setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SERVER_FOLDER		:= server
 SERVER_EXECUTABLE	:= server
 DATA_FOLDER_PATH	:= server/data
 
-CLIENT_LIB_DIR := bots/$(LANGUAGE)/client_lib
+CLIENT_LIB_DIR := /workspaces/monorepo/bots/$(LANGUAGE)/client_lib
 
 BOT_ROOT			:= bots/$(LANGUAGE)/$(DIFFICULTY)
 PLAYER_1_FOLDER		:= $(BOT_ROOT)/my-core-bot

--- a/visualizer/README.md
+++ b/visualizer/README.md
@@ -14,6 +14,7 @@ You can control the visualizer via query parameters. Multiple values are support
 |---|---|---:|---|
 | `replays` | string array (path/URL) | `/replays/replay_latest.json` | List of replay files to load. |
 | `speed` | number (`0.5` … `50`, step `0.5`) | none | Sets initial ticks/sec (also persisted to `tm.speed`). |
+| `dynamicSpeed` | `"on"` or `"off"` | `"off"` | Sets initial ticks/sec so the replay takes roughly 30s-60s to wrap up. |
 | `autoplay` | `"off"`, `"start"` or `"full"` | `"off"` | `"start"` automatically starts playback when a replay loaded, `"full"` additionally moves on to next replay file after one finished, `"off"` does neither. |
 | `ui` | `"false"` or `"true"` | _shown_ | When `false`, hides all elements with class `.ui`. |
 | `theme` | `"light"` or `"dark"` | system/light | Sets theme, persisted to `localStorage["ui.theme"]`. |

--- a/visualizer/src/ts/replay_loader/replayLoader.ts
+++ b/visualizer/src/ts/replay_loader/replayLoader.ts
@@ -1,4 +1,7 @@
-import { resetTimeManager } from "../input_manager/timeManager";
+import {
+	resetTimeManager,
+	setPlaybackSpeed,
+} from "../input_manager/timeManager";
 import { ensureIcons } from "../renderer/iconManager";
 import { getTeamIndex } from "../renderer/objectRenderer";
 import { setupRenderer } from "../renderer/renderer";
@@ -81,6 +84,29 @@ function forceHttps(url: string): string {
 		u.protocol = "https:";
 	}
 	return u.toString();
+}
+
+function isDynamicSpeedEnabled(): boolean {
+	const p = new URLSearchParams(window.location.search);
+	return (
+		(p.get("dynamicSpeed") || "off").toLowerCase() === "on" && !p.has("speed")
+	);
+}
+function computeDynamicSpeed(ticks: number): number {
+	// Calculate linear interp. graph: at 500 ticks => 20s, at 2000 ticks => 60s
+	const t0 = 500;
+	const s0 = 20;
+	const t1 = 2000;
+	const s1 = 60;
+	const slope = (s1 - s0) / (t1 - t0);
+
+	const desiredSeconds = s0 + Math.abs(ticks - t0) * slope;
+
+	let speed = ticks / desiredSeconds;
+
+	speed = Math.max(5, Math.min(25, speed));
+
+	return Math.round(speed / 0.5) * 0.5;
 }
 
 class ReplayLoader {
@@ -282,6 +308,9 @@ async function resetReplay(reason: string = "reset"): Promise<void> {
 	setupRenderer();
 	ensureIcons();
 	updateWinDisplayEmojis();
+	if (isDynamicSpeedEnabled()) {
+		setPlaybackSpeed(computeDynamicSpeed(totalReplayTicks));
+	}
 	console.debug(
 		`Replay reset (${reason}). override=${Boolean(replayDataOverride)} etag=${lastEtag}`,
 	);


### PR DESCRIPTION
We may need to tweak the values a bit until they're perfect after the next event, but this should be good generally speaking I think, as most games run between roughly 500 to 2000 ticks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a `dynamicSpeed` URL parameter that automatically adjusts replay playback speed to complete within 30-60 seconds.

* **Documentation**
  * Updated README with documentation for the new `dynamicSpeed` parameter and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->