### PR TITLE
Add object info like printf

### DIFF
--- a/bots/c/client_lib/inc/core_lib.h
+++ b/bots/c/client_lib/inc/core_lib.h
@@ -274,7 +274,8 @@ t_unit_config *core_get_unitConfig(t_unit_type type);
 /// @brief Add debug information to an object for visualization
 /// @details This function accumulates debug strings for objects. Multiple calls per tick will append the strings (with newlines).
 /// @param obj The object to attach debug info to
-/// @param info The debug string to add
+/// @param format printf-style format debug string to add
+/// @param ... Format arguments matching the format string
 void core_debug_addObjectInfo(const t_obj *obj, const char *format, ...);
 
 /// @brief Add a step to the end of the debug path of an object for visualization

--- a/bots/c/client_lib/inc/core_lib.h
+++ b/bots/c/client_lib/inc/core_lib.h
@@ -5,6 +5,7 @@
 
 #include <limits.h>
 #include <math.h>
+#include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -274,7 +275,7 @@ t_unit_config *core_get_unitConfig(t_unit_type type);
 /// @details This function accumulates debug strings for objects. Multiple calls per tick will append the strings (with newlines).
 /// @param obj The object to attach debug info to
 /// @param info The debug string to add
-void core_debug_addObjectInfo(const t_obj *obj, const char *info);
+void core_debug_addObjectInfo(const t_obj *obj, const char *format, ...);
 
 /// @brief Add a step to the end of the debug path of an object for visualization
 /// @param unit The unit to attach the debug path step to

--- a/bots/c/client_lib/inc/core_lib.h
+++ b/bots/c/client_lib/inc/core_lib.h
@@ -272,7 +272,7 @@ t_unit_config *core_get_unitConfig(t_unit_type type);
 // ----- DEBUG FUNCTIONS -----
 
 /// @brief Add debug information to an object for visualization
-/// @details This function accumulates debug strings for objects. Multiple calls per tick will append the strings (with newlines).
+/// @details This function accumulates debug strings for objects. Multiple calls per tick will append the strings.
 /// @param obj The object to attach debug info to
 /// @param format printf-style format debug string to add
 /// @param ... Format arguments matching the format string

--- a/bots/c/client_lib/src/public/debug.c
+++ b/bots/c/client_lib/src/public/debug.c
@@ -31,23 +31,51 @@ static t_debug_entry *core_static_findOrCreateEntry(unsigned long object_id)
 	return entry;
 }
 
-void core_debug_addObjectInfo(const t_obj *obj, const char *info)
+void core_debug_addObjectInfo(const t_obj *obj, const char *format, ...)
 {
-	if (!obj || !info) return;
+	if (!obj || !format) return;
 
 	t_debug_entry *entry = core_static_findOrCreateEntry(obj->id);
+	if (!entry) return;
 
+	// format the new info string
+	va_list ap;
+	va_start(ap, format);
+
+	va_list ap2;
+	va_copy(ap2, ap);
+
+	int needed = vsnprintf(NULL, 0, format, ap);
+	va_end(ap);
+
+	if (needed < 0)
+	{
+		va_end(ap2);
+		return;
+	}
+
+	char *msg = (char *)malloc((size_t)needed + 1);
+	if (!msg)
+	{
+		va_end(ap2);
+		return;
+	}
+
+	vsnprintf(msg, (size_t)needed + 1, format, ap2);
+	va_end(ap2);
+
+	// append to debug info
 	if (entry->info == NULL)
 	{
-		// First info for this object
-		entry->info = strdup(info);
+		entry->info = msg;
 	}
 	else
 	{
 		size_t old_len = strlen(entry->info);
-		size_t new_len = strlen(info);
+		size_t new_len = strlen(msg);
 		entry->info = realloc(entry->info, old_len + new_len + 1);
-		strcat(entry->info, info);
+		strcat(entry->info, msg);
+		free(msg);
 	}
 }
 

--- a/bots/c/hardcore/my-core-bot/src/main.c
+++ b/bots/c/hardcore/my-core-bot/src/main.c
@@ -42,7 +42,8 @@ void ft_on_tick(unsigned long tick)
 			core_action_move(own_team_warriors[i], path.steps[0]);
 		}
 
-		core_debug_addObjectInfo(own_team_warriors[i], "Moving towards opponent core :D\n");
+		core_debug_addObjectInfo(own_team_warriors[i], "Moving towards opponent core at [%d,%d] :D\n",
+								 ft_get_core_opponent()->pos.x, ft_get_core_opponent()->pos.y);
 		core_action_attack(own_team_warriors[i], ft_get_core_opponent());
 
 		// Clean up

--- a/bots/c/softcore/my-core-bot/src/main.c
+++ b/bots/c/softcore/my-core-bot/src/main.c
@@ -18,6 +18,10 @@ void ft_on_tick(unsigned long tick)
 
 	t_obj **units = ft_get_units_own();
 	for (int i = 0; units && units[i]; i++)
+	{
 		core_action_pathfind(units[i], ft_get_core_opponent()->pos);
+		core_debug_addObjectInfo(units[i], "I am a warrior! 🗡️ - I am heading for the opponent core at [%d,%d]! 🏰\n",
+								 ft_get_core_opponent()->pos.x, ft_get_core_opponent()->pos.y);
+	}
 	free(units);
 }

--- a/wiki/reference/debug/core_debug_addObjectInfo.md
+++ b/wiki/reference/debug/core_debug_addObjectInfo.md
@@ -12,6 +12,8 @@ https://github.com/42core-team/monorepo/blob/dev/bots/c/client_lib/src/public/de
 
 Attaches an arbitrary string to any object (typically an object or your core) that will be displayed in the object's tooltip if someone hovers over the object in the visualizer. May be helpful for a variety of debugging purposes.
 
+You can also format strings dynamically by using the function the same way as one would use `printf`. All flags work as normal. Check out the example below for details.
+
 This function can be called multiple times in a given tick, all of the string the function is called with will be appended together at the end.
 
 > [!WARNING]
@@ -20,7 +22,7 @@ This function can be called multiple times in a given tick, all of the string th
 ## Signature
 
 ```c
-void core_debug_addObjectInfo(const t_obj *obj, const char *info);
+void core_debug_addObjectInfo(const t_obj *obj, const char *format, ...);
 ```
 
 ## Parameters
@@ -37,7 +39,7 @@ void
 ```c
 if (path.length > 0)
 	core_action_move(own_team_warriors[i], path.steps[0]);
-core_debug_addObjectInfo(own_team_warriors[i], "Moving towards opponent core\n");
+core_debug_addObjectInfo(units[i], "I am a warrior! 🗡️ - I am heading for the opponent core at [%d,%d]! 🏰\n", ft_get_core_opponent()->pos.x, ft_get_core_opponent()->pos.y);
 core_action_attack(own_team_warriors[i], ft_get_core_opponent());
 ```
 


### PR DESCRIPTION
Previously you had to manually format a string together with sprintf if you wanted dynamic data in the debug data. This is no longer the case, as you can now use the function like printf. This will hopefully make it so easy to use that more than one person does so. It's also cool and I didn't know it was possible.

`core_debug_addObjectInfo(units[i], "I am a warrior! 🗡️ - I am heading for the opponent core at [%d,%d]! 🏰\n", ft_get_core_opponent()->pos.x, ft_get_core_opponent()->pos.y);`

@Peu77 @Reptudn Tagging you guys for PRs related to the client lib from now on as you guys are writing your own versions so you know when you have to make changes to maintain your version, please do that. Also please review this PR. I don't think tsConn needs this, but I think goConn should also mirror `fmt.Printf` once it's maintained and up-to-date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debug logging now supports printf-style formatted output with dynamic values, enabling richer messages (e.g., object coordinates).
  * Bots now emit more detailed runtime debug messages, including per-unit and core coordinate details for better traceability.

* **Documentation**
  * Updated reference docs and examples to show the new formatted logging usage and multi-message behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->