### PR TITLE
Fail visualizer workflow when ref tag is missing

### DIFF
--- a/.github/workflows/visualizer.yml
+++ b/.github/workflows/visualizer.yml
@@ -220,30 +220,34 @@ jobs:
             echo "Manifest created for $tag"
           done
 
-          # Create manifest for additional version tags if they exist
           if [ -n "${{ steps.version-tags.outputs.additional-tags }}" ]; then
-            # Find the ref tag from the base tags to use as source
             REF_TAG=""
             for tag in $TAGS; do
-              if [[ "$tag" == *"$GITHUB_REF_NAME" ]] && [[ "$tag" != *"-"* ]]; then
+              if [[ -z "$tag" ]]; then
+                continue
+              fi
+              ref_part="${tag##*:}"
+              if [[ "$ref_part" == "$GITHUB_REF_NAME" ]]; then
                 REF_TAG="$tag"
                 break
               fi
             done
-            
+
             if [ -n "$REF_TAG" ]; then
               IFS=',' read -r -a additional_tags <<< "${{ steps.version-tags.outputs.additional-tags }}"
               for tag in "${additional_tags[@]}"; do
                 if [ -n "$tag" ]; then
                   echo "Creating additional tag: $tag from $REF_TAG"
-                  # Create additional tags from the ref tag that was already built
                   docker buildx imagetools create -t "$tag" \
                     "${REF_TAG}-amd64" \
                     "${REF_TAG}-arm64"
-                  
+
                   echo "Additional manifest created for $tag"
                 fi
               done
+            else
+              echo "ERROR: Could not find ref tag matching $GITHUB_REF_NAME in base tags; additional version tags were not created." >&2
+              exit 1
             fi
           fi
 


### PR DESCRIPTION
## Summary
- Tighten the visualizer workflow so additional version tags are only created when a matching ref tag is found.
- Add explicit validation for the ref tag lookup instead of silently skipping additional tag creation.
- Emit a clear error and fail the job when the expected base tag is missing.

## Testing
- Not run (workflow-only change).
- Reviewed the workflow diff to confirm additional tags now exit non-zero when no matching ref tag is present.
- Confirmed the ref tag match logic now compares the tag suffix against `GITHUB_REF_NAME`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved build manifest creation robustness with enhanced tag matching logic for more reliable version identification.
  * Added explicit error reporting to build workflows; errors are now clearly reported instead of silently skipping manifest creation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->