### PR TITLE
Add baseUnitCost to game config

### DIFF
--- a/bots/c/hardcore/configs/game.config.json
+++ b/bots/c/hardcore/configs/game.config.json
@@ -24,7 +24,7 @@
 	},
 	"components": {
 		"maxComponentsPerUnit": 5,
-		"baseUnitCost": 20,
+		"unitDefaultCost": 20,
 		"unitDefaultProperties": {
 			"hp": 5,
 			"baseActionCooldown": 3,

--- a/bots/c/hardcore/configs/game.config.json
+++ b/bots/c/hardcore/configs/game.config.json
@@ -24,6 +24,7 @@
 	},
 	"components": {
 		"maxComponentsPerUnit": 5,
+		"baseUnitCost": 20,
 		"unitDefaultProperties": {
 			"hp": 5,
 			"baseActionCooldown": 3,

--- a/bots/c/softcore/configs/game.config.json
+++ b/bots/c/softcore/configs/game.config.json
@@ -18,7 +18,7 @@
 	},
 	"components": {
 		"maxComponentsPerUnit": 5,
-		"baseUnitCost": 20,
+		"unitDefaultCost": 20,
 		"unitDefaultProperties": {
 			"hp": 5,
 			"baseActionCooldown": 3,

--- a/bots/c/softcore/configs/game.config.json
+++ b/bots/c/softcore/configs/game.config.json
@@ -18,6 +18,7 @@
 	},
 	"components": {
 		"maxComponentsPerUnit": 5,
+		"baseUnitCost": 20,
 		"unitDefaultProperties": {
 			"hp": 5,
 			"baseActionCooldown": 3,

--- a/server/data/json-schemas/configs/game-config.schema.json
+++ b/server/data/json-schemas/configs/game-config.schema.json
@@ -307,7 +307,7 @@
         },
         "cost": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": 1,
           "maximum": 10000000
         },
         "visualizer_asset_prioritized": {
@@ -324,12 +324,18 @@
       "additionalProperties": false,
       "required": [
         "maxComponentsPerUnit",
+        "baseUnitCost",
         "unitDefaultProperties",
         "components",
         "invalidConditions"
       ],
       "properties": {
         "maxComponentsPerUnit": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000000
+        },
+        "baseUnitCost": {
           "type": "integer",
           "minimum": 0,
           "maximum": 10000000

--- a/server/data/json-schemas/configs/game-config.schema.json
+++ b/server/data/json-schemas/configs/game-config.schema.json
@@ -307,7 +307,7 @@
         },
         "cost": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "maximum": 10000000
         },
         "visualizer_asset_prioritized": {
@@ -324,7 +324,7 @@
       "additionalProperties": false,
       "required": [
         "maxComponentsPerUnit",
-        "baseUnitCost",
+        "unitDefaultCost",
         "unitDefaultProperties",
         "components",
         "invalidConditions"
@@ -335,9 +335,9 @@
           "minimum": 0,
           "maximum": 10000000
         },
-        "baseUnitCost": {
+        "unitDefaultCost": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": 1,
           "maximum": 10000000
         },
         "unitDefaultProperties": {

--- a/server/inc/config/Config.h
+++ b/server/inc/config/Config.h
@@ -39,7 +39,7 @@ struct GameConfig
 	unsigned int wallHp;
 
 	unsigned int maxComponentsPerUnit;
-	unsigned int baseUnitCost;
+	unsigned int defaultUnitCost;
 	std::map<UnitProperty, int> defaultUnitProperties;
 	std::vector<ComponentConfig> componentTypes;
 	std::vector<InvalidConditionConfig> invalidConditions;

--- a/server/inc/config/Config.h
+++ b/server/inc/config/Config.h
@@ -39,6 +39,7 @@ struct GameConfig
 	unsigned int wallHp;
 
 	unsigned int maxComponentsPerUnit;
+	unsigned int baseUnitCost;
 	std::map<UnitProperty, int> defaultUnitProperties;
 	std::vector<ComponentConfig> componentTypes;
 	std::vector<InvalidConditionConfig> invalidConditions;

--- a/server/src/action/CreateAction.cpp
+++ b/server/src/action/CreateAction.cpp
@@ -92,7 +92,7 @@ std::string CreateAction::execute(Core *core)
 	}
 
 	std::map<std::string, unsigned int> componentCounts;
-	unsigned int unitCost = 0;
+	unsigned int unitCost = Config::game().baseUnitCost;
 
 	for (const std::string &componentId : components_)
 	{

--- a/server/src/action/CreateAction.cpp
+++ b/server/src/action/CreateAction.cpp
@@ -92,7 +92,7 @@ std::string CreateAction::execute(Core *core)
 	}
 
 	std::map<std::string, unsigned int> componentCounts;
-	unsigned int unitCost = Config::game().baseUnitCost;
+	unsigned int unitCost = Config::game().defaultUnitCost;
 
 	for (const std::string &componentId : components_)
 	{

--- a/server/src/config/Config.cpp
+++ b/server/src/config/Config.cpp
@@ -328,6 +328,7 @@ static GameConfig parseGameConfig()
 	json components = j.at("components").get<json>();
 
 	config.maxComponentsPerUnit = components.at("maxComponentsPerUnit").get<unsigned int>();
+	config.baseUnitCost = components.at("baseUnitCost").get<unsigned int>();
 
 	const json &defaults = components.at("unitDefaultProperties");
 	for (const auto &[name, valueJson] : defaults.items())

--- a/server/src/config/Config.cpp
+++ b/server/src/config/Config.cpp
@@ -328,7 +328,7 @@ static GameConfig parseGameConfig()
 	json components = j.at("components").get<json>();
 
 	config.maxComponentsPerUnit = components.at("maxComponentsPerUnit").get<unsigned int>();
-	config.baseUnitCost = components.at("baseUnitCost").get<unsigned int>();
+	config.defaultUnitCost = components.at("unitDefaultCost").get<unsigned int>();
 
 	const json &defaults = components.at("unitDefaultProperties");
 	for (const auto &[name, valueJson] : defaults.items())


### PR DESCRIPTION
Units now have a configurable base cost in addition to component costs, so unit price can't drop to zero for cheap component combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable base unit cost (`unitDefaultCost`) to game configuration for both game modes.
  * Unit spawning now uses this base cost when computing placement cost and balance impact.

* **Bug Fixes**
  * Updated configuration validation to require a non-zero component/unit default cost (with defined min/max bounds).
  * Ensured configuration parsing and schema support the new required value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->