### PR TITLE
Add live replay streaming to the visualizer

### DIFF
--- a/server/data/json-schemas/configs/server-config.schema.json
+++ b/server/data/json-schemas/configs/server-config.schema.json
@@ -12,6 +12,11 @@
 		"clientPacketsMaxSizeKb"
 	],
 	"properties": {
+		"liveReplayPort": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 65535
+		},
 		"replayFolderPaths": {
 			"type": "array",
 			"minItems": 1,

--- a/server/inc/config/Config.h
+++ b/server/inc/config/Config.h
@@ -89,6 +89,7 @@ struct ComponentConfig
 struct ServerConfig
 {
 	std::vector<std::string> replayFolderPaths;
+	unsigned int liveReplayPort;
 	unsigned int timeoutTicks;
 	unsigned int timeoutMs;
 	unsigned int clientWaitTimeoutMs;

--- a/server/inc/game/ReplayEncoder.h
+++ b/server/inc/game/ReplayEncoder.h
@@ -8,6 +8,7 @@ using json = nlohmann::ordered_json;
 #include "Config.h"
 #include "Core.h"
 #include "Logger.h"
+#include "LiveReplayServer.h"
 #include "Stats.h"
 
 #include <cstdlib>
@@ -59,6 +60,7 @@ class ReplayEncoder
 
 	void includeConfig(json &config);
 	json &getCustomData(void) { return customData_; }
+	void startLiveUpdates(unsigned int port);
 
 	void exportReplay() const;
 	void saveReplay(const json &replayData) const;
@@ -67,6 +69,7 @@ class ReplayEncoder
 
   private:
 	json encodeMiscSection() const;
+	json encodeReplay() const;
 
 	json ticks_ = json::array();
 	json config_ = json::object();
@@ -74,6 +77,7 @@ class ReplayEncoder
 
 	unsigned long long lastTickCount_;
 	std::unordered_map<unsigned int, team_data_t> teamData_;
+	mutable LiveReplayServer liveReplayServer_;
 };
 
 #endif // REPLAY_ENCODER_H

--- a/server/inc/net/LiveReplayServer.h
+++ b/server/inc/net/LiveReplayServer.h
@@ -1,0 +1,41 @@
+#ifndef LIVE_REPLAY_SERVER_H
+#define LIVE_REPLAY_SERVER_H
+
+#include "json.hpp"
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using json = nlohmann::ordered_json;
+
+class LiveReplayServer
+{
+  public:
+	LiveReplayServer() = default;
+	~LiveReplayServer();
+
+	LiveReplayServer(const LiveReplayServer &) = delete;
+	LiveReplayServer &operator=(const LiveReplayServer &) = delete;
+
+	bool start(unsigned int port, const json &initialReplay);
+	void publishTick(unsigned long long tick, const json &tickData);
+	void publishComplete(const json &replay);
+	bool isRunning() const { return running_; }
+
+  private:
+	void acceptLoop();
+	void broadcast(const std::string &message);
+	bool sendFrame(int clientFd, const std::string &payload) const;
+
+	std::atomic<bool> running_{false};
+	int listenFd_ = -1;
+	std::thread acceptThread_;
+	mutable std::mutex mutex_;
+	std::vector<int> clients_;
+	json replay_ = json::object();
+};
+
+#endif // LIVE_REPLAY_SERVER_H

--- a/server/src/config/Config.cpp
+++ b/server/src/config/Config.cpp
@@ -266,6 +266,7 @@ static ServerConfig parseServerConfig()
 	{
 		config.replayFolderPaths = {"replays"};
 	}
+	config.liveReplayPort = j.value("liveReplayPort", 0U);
 	config.timeoutTicks = j.at("timeoutTicks").get<unsigned int>();
 	config.timeoutMs = j.at("timeoutMs").get<unsigned int>();
 	config.clientWaitTimeoutMs = j.at("clientWaitTimeoutMs").get<unsigned int>();

--- a/server/src/game/ReplayEncoder.cpp
+++ b/server/src/game/ReplayEncoder.cpp
@@ -21,6 +21,7 @@ void ReplayEncoder::addTickState(json &state, unsigned long long tick,
 	if (!state.empty()) ticks_[std::to_string(tick)] = state;
 
 	lastTickCount_ = tick;
+	liveReplayServer_.publishTick(tick, state);
 }
 
 void ReplayEncoder::registerExpectedTeam(unsigned int teamId)
@@ -64,6 +65,13 @@ bool ReplayEncoder::wasConnectedInitially(unsigned int teamId) const
 void ReplayEncoder::includeConfig(json &config)
 {
 	config_ = config;
+}
+
+void ReplayEncoder::startLiveUpdates(unsigned int port)
+{
+	if (port == 0) return;
+	if (!liveReplayServer_.start(port, encodeReplay()))
+		Logger::Log(LogLevel::WARNING, "Could not start live replay WebSocket on port " + std::to_string(port) + ".");
 }
 
 void ReplayEncoder::verifyReplaySaveFolder()
@@ -132,15 +140,21 @@ void ReplayEncoder::exportReplay() const
 		return;
 	}
 
+	json replayData = encodeReplay();
+	liveReplayServer_.publishComplete(replayData);
+	saveReplay(replayData);
+}
+
+json ReplayEncoder::encodeReplay() const
+{
 	json replayData;
 	replayData["misc"] = encodeMiscSection();
-	for (auto &kv : customData_.items())
+	for (const auto &kv : customData_.items())
 		replayData["misc"][kv.key()] = kv.value();
 	replayData["ticks"] = !ticks_.empty() ? ticks_ : json::array();
 	replayData["config"] = config_;
 	replayData["full_tick_amount"] = lastTickCount_;
-
-	saveReplay(replayData);
+	return replayData;
 }
 void ReplayEncoder::saveReplay(const json &replayData) const
 {

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -206,6 +206,7 @@ int main(int argc, char *argv[])
 				std::to_string(expectedTeamIds.size()) + " teams connected.");
 
 	Game game(connectedTeamIds);
+	ReplayEncoder::instance().startLiveUpdates(Config::server().liveReplayPort);
 
 	for (auto &pair : bridges)
 		game.addBridge(std::move(pair.second));

--- a/server/src/net/LiveReplayServer.cpp
+++ b/server/src/net/LiveReplayServer.cpp
@@ -1,0 +1,331 @@
+#include "LiveReplayServer.h"
+
+#include "Logger.h"
+
+#include <arpa/inet.h>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstring>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sstream>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace
+{
+uint32_t rotateLeft(uint32_t value, unsigned int bits)
+{
+	return (value << bits) | (value >> (32 - bits));
+}
+
+std::array<unsigned char, 20> sha1(const std::string &input)
+{
+	std::vector<unsigned char> message(input.begin(), input.end());
+	const uint64_t bitLength = static_cast<uint64_t>(message.size()) * 8;
+	message.push_back(0x80);
+	while ((message.size() % 64) != 56)
+		message.push_back(0);
+	for (int i = 7; i >= 0; --i)
+		message.push_back(static_cast<unsigned char>((bitLength >> (i * 8)) & 0xff));
+
+	uint32_t h0 = 0x67452301;
+	uint32_t h1 = 0xefcdab89;
+	uint32_t h2 = 0x98badcfe;
+	uint32_t h3 = 0x10325476;
+	uint32_t h4 = 0xc3d2e1f0;
+
+	for (size_t chunk = 0; chunk < message.size(); chunk += 64)
+	{
+		uint32_t words[80]{};
+		for (size_t i = 0; i < 16; ++i)
+		{
+			const size_t offset = chunk + i * 4;
+			words[i] = (static_cast<uint32_t>(message[offset]) << 24) |
+					   (static_cast<uint32_t>(message[offset + 1]) << 16) |
+					   (static_cast<uint32_t>(message[offset + 2]) << 8) |
+					   static_cast<uint32_t>(message[offset + 3]);
+		}
+		for (size_t i = 16; i < 80; ++i)
+			words[i] = rotateLeft(words[i - 3] ^ words[i - 8] ^ words[i - 14] ^ words[i - 16], 1);
+
+		uint32_t a = h0;
+		uint32_t b = h1;
+		uint32_t c = h2;
+		uint32_t d = h3;
+		uint32_t e = h4;
+		for (size_t i = 0; i < 80; ++i)
+		{
+			uint32_t f;
+			uint32_t k;
+			if (i < 20)
+			{
+				f = (b & c) | ((~b) & d);
+				k = 0x5a827999;
+			}
+			else if (i < 40)
+			{
+				f = b ^ c ^ d;
+				k = 0x6ed9eba1;
+			}
+			else if (i < 60)
+			{
+				f = (b & c) | (b & d) | (c & d);
+				k = 0x8f1bbcdc;
+			}
+			else
+			{
+				f = b ^ c ^ d;
+				k = 0xca62c1d6;
+			}
+			const uint32_t temp = rotateLeft(a, 5) + f + e + k + words[i];
+			e = d;
+			d = c;
+			c = rotateLeft(b, 30);
+			b = a;
+			a = temp;
+		}
+		h0 += a;
+		h1 += b;
+		h2 += c;
+		h3 += d;
+		h4 += e;
+	}
+
+	std::array<unsigned char, 20> digest{};
+	const uint32_t hashes[] = {h0, h1, h2, h3, h4};
+	for (size_t i = 0; i < 5; ++i)
+		for (size_t j = 0; j < 4; ++j)
+			digest[i * 4 + j] = static_cast<unsigned char>((hashes[i] >> (24 - j * 8)) & 0xff);
+	return digest;
+}
+
+std::string base64(const unsigned char *data, size_t length)
+{
+	static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	std::string result;
+	for (size_t i = 0; i < length; i += 3)
+	{
+		const uint32_t value = (static_cast<uint32_t>(data[i]) << 16) |
+						   (i + 1 < length ? static_cast<uint32_t>(data[i + 1]) << 8 : 0) |
+						   (i + 2 < length ? static_cast<uint32_t>(data[i + 2]) : 0);
+		result.push_back(alphabet[(value >> 18) & 0x3f]);
+		result.push_back(alphabet[(value >> 12) & 0x3f]);
+		result.push_back(i + 1 < length ? alphabet[(value >> 6) & 0x3f] : '=');
+		result.push_back(i + 2 < length ? alphabet[value & 0x3f] : '=');
+	}
+	return result;
+}
+
+std::string websocketAcceptKey(const std::string &key)
+{
+	const auto digest = sha1(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+	return base64(digest.data(), digest.size());
+}
+
+std::string headerValue(const std::string &request, const std::string &header)
+{
+	std::istringstream lines(request);
+	std::string line;
+	while (std::getline(lines, line))
+	{
+		if (!line.empty() && line.back() == '\r') line.pop_back();
+		const size_t colon = line.find(':');
+		if (colon == std::string::npos || colon != header.size()) continue;
+		bool matches = true;
+		for (size_t i = 0; i < header.size(); ++i)
+		{
+			if (std::tolower(static_cast<unsigned char>(line[i])) !=
+				std::tolower(static_cast<unsigned char>(header[i])))
+			{
+				matches = false;
+				break;
+			}
+		}
+		if (!matches) continue;
+		size_t start = colon + 1;
+		while (start < line.size() && line[start] == ' ')
+			++start;
+		return line.substr(start);
+	}
+	return {};
+}
+
+bool sendAll(int fd, const unsigned char *data, size_t length)
+{
+	while (length > 0)
+	{
+#ifdef MSG_NOSIGNAL
+		const ssize_t sent = send(fd, data, length, MSG_NOSIGNAL);
+#else
+		const ssize_t sent = send(fd, data, length, 0);
+#endif
+		if (sent <= 0) return false;
+		data += sent;
+		length -= static_cast<size_t>(sent);
+	}
+	return true;
+}
+} // namespace
+
+LiveReplayServer::~LiveReplayServer()
+{
+	running_ = false;
+	if (listenFd_ >= 0)
+	{
+		shutdown(listenFd_, SHUT_RDWR);
+		close(listenFd_);
+		listenFd_ = -1;
+	}
+	if (acceptThread_.joinable()) acceptThread_.join();
+	std::lock_guard<std::mutex> lock(mutex_);
+	for (int fd : clients_)
+		close(fd);
+}
+
+bool LiveReplayServer::start(unsigned int port, const json &initialReplay)
+{
+	if (port == 0 || running_) return false;
+	listenFd_ = socket(AF_INET, SOCK_STREAM, 0);
+	if (listenFd_ < 0) return false;
+	int enabled = 1;
+	setsockopt(listenFd_, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled));
+
+	sockaddr_in address{};
+	address.sin_family = AF_INET;
+	address.sin_addr.s_addr = INADDR_ANY;
+	address.sin_port = htons(static_cast<uint16_t>(port));
+	if (bind(listenFd_, reinterpret_cast<sockaddr *>(&address), sizeof(address)) < 0 ||
+		listen(listenFd_, SOMAXCONN) < 0)
+	{
+		close(listenFd_);
+		listenFd_ = -1;
+		return false;
+	}
+
+	replay_ = initialReplay;
+	running_ = true;
+	acceptThread_ = std::thread(&LiveReplayServer::acceptLoop, this);
+	Logger::Log("Live replay WebSocket listening on port " + std::to_string(port) + "...");
+	return true;
+}
+
+void LiveReplayServer::acceptLoop()
+{
+	while (running_)
+	{
+		const int clientFd = accept(listenFd_, nullptr, nullptr);
+		if (clientFd < 0)
+		{
+			if (running_) Logger::Log(LogLevel::WARNING, "Could not accept live replay WebSocket client.");
+			continue;
+		}
+
+		std::string request;
+		std::array<char, 2048> buffer{};
+		while (request.find("\r\n\r\n") == std::string::npos && request.size() < 8192)
+		{
+			const ssize_t received = recv(clientFd, buffer.data(), buffer.size(), 0);
+			if (received <= 0) break;
+			request.append(buffer.data(), static_cast<size_t>(received));
+		}
+		const std::string key = headerValue(request, "Sec-WebSocket-Key");
+		if (key.empty())
+		{
+			close(clientFd);
+			continue;
+		}
+
+		const std::string response = "HTTP/1.1 101 Switching Protocols\r\n"
+								 "Upgrade: websocket\r\n"
+								 "Connection: Upgrade\r\n"
+								 "Sec-WebSocket-Accept: " +
+							 websocketAcceptKey(key) + "\r\n\r\n";
+		if (!sendAll(clientFd, reinterpret_cast<const unsigned char *>(response.data()), response.size()))
+		{
+			close(clientFd);
+			continue;
+		}
+
+		std::lock_guard<std::mutex> lock(mutex_);
+		json message = {{"type", "snapshot"}, {"replay", replay_}};
+		if (sendFrame(clientFd, message.dump()))
+		{
+			const int flags = fcntl(clientFd, F_GETFL, 0);
+			if (flags >= 0) fcntl(clientFd, F_SETFL, flags | O_NONBLOCK);
+			clients_.push_back(clientFd);
+		}
+		else
+			close(clientFd);
+	}
+}
+
+bool LiveReplayServer::sendFrame(int clientFd, const std::string &payload) const
+{
+	std::vector<unsigned char> frame;
+	frame.reserve(payload.size() + 10);
+	frame.push_back(0x81);
+	if (payload.size() <= 125)
+	{
+		frame.push_back(static_cast<unsigned char>(payload.size()));
+	}
+	else if (payload.size() <= 65535)
+	{
+		frame.push_back(126);
+		frame.push_back(static_cast<unsigned char>((payload.size() >> 8) & 0xff));
+		frame.push_back(static_cast<unsigned char>(payload.size() & 0xff));
+	}
+	else
+	{
+		frame.push_back(127);
+		for (int shift = 56; shift >= 0; shift -= 8)
+			frame.push_back(static_cast<unsigned char>((static_cast<uint64_t>(payload.size()) >> shift) & 0xff));
+	}
+	frame.insert(frame.end(), payload.begin(), payload.end());
+	return sendAll(clientFd, frame.data(), frame.size());
+}
+
+void LiveReplayServer::broadcast(const std::string &message)
+{
+	std::lock_guard<std::mutex> lock(mutex_);
+	for (auto it = clients_.begin(); it != clients_.end();)
+	{
+		if (sendFrame(*it, message))
+		{
+			++it;
+		}
+		else
+		{
+			close(*it);
+			it = clients_.erase(it);
+		}
+	}
+}
+
+void LiveReplayServer::publishTick(unsigned long long tick, const json &tickData)
+{
+	if (!running_) return;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		if (!tickData.empty())
+		{
+			if (!replay_["ticks"].is_object()) replay_["ticks"] = json::object();
+			replay_["ticks"][std::to_string(tick)] = tickData;
+		}
+		replay_["full_tick_amount"] = tick;
+	}
+	json message = {{"type", "tick"}, {"tick", tick}, {"data", tickData}};
+	broadcast(message.dump());
+}
+
+void LiveReplayServer::publishComplete(const json &replay)
+{
+	if (!running_) return;
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		replay_ = replay;
+	}
+	json message = {{"type", "complete"}, {"replay", replay}};
+	broadcast(message.dump());
+}

--- a/visualizer/README.md
+++ b/visualizer/README.md
@@ -13,6 +13,7 @@ You can control the visualizer via query parameters. Multiple values are support
 | Param | Type / Values | Default | Effect |
 |---|---|---:|---|
 | `replays` | string array (path/URL) | `/replays/replay_latest.json` | List of replay files to load. |
+| `live` | WebSocket URL | none | Streams the replay as it is played. An empty value uses `ws://<visualizer-host>:4445` (or `wss://` on HTTPS). This takes precedence over `replays`. |
 | `speed` | number (`0.5` … `50`, step `0.5`) | none | Sets initial ticks/sec (also persisted to `tm.speed`). |
 | `dynamicSpeed` | `"on"` or `"off"` | `"off"` | Sets initial ticks/sec so the replay takes roughly 30s-60s to wrap up. |
 | `autoplay` | `"off"`, `"start"` or `"full"` | `"off"` | `"start"` automatically starts playback when a replay loaded, `"full"` additionally moves on to next replay file after one finished, `"off"` does neither. |
@@ -37,6 +38,10 @@ You can control the visualizer via query parameters. Multiple values are support
 [http://localhost:4242/?autoplay=/a.json,/b.json,/c.json\&themeColor=%235A7CFF](http://localhost:4242/?autoplay=/a.json,/b.json,/c.json&themeColor=%235A7CFF)
 
 Note: URL-encode `#` as `%23` in links.
+
+## Live replays
+
+Set the optional `liveReplayPort` in the server config, for example `4445`, then open the visualizer with `?live=ws://localhost:4445`. The server sends an initial snapshot containing every tick already played and streams subsequent replay-format tick diffs. The saved `replay_latest.json` format and normal file playback are unchanged.
 - Headless wall display (no UI), suppress version warning:
 
 [http://localhost:4242/?ui=false\&suppress\_version\_warning=true](http://localhost:4242/?ui=false&suppress_version_warning=true)

--- a/visualizer/src/ts/input_manager/timeManager.ts
+++ b/visualizer/src/ts/input_manager/timeManager.ts
@@ -422,3 +422,10 @@ export function resetTimeManager() {
 	tickTimelineNumberInput.max = (getTotalTicks() - 1).toString();
 	tickTimelineNumberInput.value = "0";
 }
+
+export function updateTimeRange() {
+	const max = Math.max(1, getTotalTicks()) - 1;
+	tickTimelineSlider.max = String(max);
+	tickTimelineNumberInput.max = String(max);
+	if (tick > max) setTick(max);
+}

--- a/visualizer/src/ts/main.ts
+++ b/visualizer/src/ts/main.ts
@@ -26,12 +26,28 @@ window.addEventListener("DOMContentLoaded", async () => {
 
 	// project imports
 
-	const { setupReplayLoader } = await import("./replay_loader/replayLoader.js");
+	const { setupLiveReplayLoader, setupReplayLoader } = await import(
+		"./replay_loader/replayLoader.js"
+	);
 	const { setupTimeManager, startPlayback, isAtEnd } = await import(
 		"./input_manager/timeManager.js"
 	);
 
-	await setupReplayLoader(replays[0]);
+	const liveMode = urlParams.has("live");
+	if (liveMode) {
+		const defaultProtocol =
+			window.location.protocol === "https:" ? "wss:" : "ws:";
+		const liveUrl =
+			urlParams.get("live") ||
+			`${defaultProtocol}//${window.location.hostname}:4445`;
+		await setupLiveReplayLoader(
+			liveUrl,
+			25,
+			urlParams.has("autoplay") && urlParams.get("autoplay") !== "off",
+		);
+	} else {
+		await setupReplayLoader(replays[0]);
+	}
 	await setupTimeManager();
 	if (urlParams.has("autoplay") && urlParams.get("autoplay") !== "off")
 		startPlayback();
@@ -50,7 +66,11 @@ window.addEventListener("DOMContentLoaded", async () => {
 			}
 		}, 500);
 	};
-	if (urlParams.has("autoplay") && urlParams.get("autoplay") === "full")
+	if (
+		!liveMode &&
+		urlParams.has("autoplay") &&
+		urlParams.get("autoplay") === "full"
+	)
 		watchAndAdvance();
 
 	// svg layout height renderer
@@ -116,9 +136,6 @@ window.addEventListener("DOMContentLoaded", async () => {
 	}
 	const bgColorParam = urlParams.get("bgColor");
 	if (typeof bgColorParam === "string") {
-		document.documentElement.style.setProperty(
-			"--app-bg",
-			`#${bgColorParam}`,
-		);
+		document.documentElement.style.setProperty("--app-bg", `#${bgColorParam}`);
 	}
 });

--- a/visualizer/src/ts/replay_loader/replayLoader.ts
+++ b/visualizer/src/ts/replay_loader/replayLoader.ts
@@ -1,6 +1,8 @@
 import {
 	resetTimeManager,
 	setPlaybackSpeed,
+	startPlayback,
+	updateTimeRange,
 } from "../input_manager/timeManager";
 import { ensureIcons } from "../renderer/iconManager";
 import { getTeamIndex } from "../renderer/objectRenderer";
@@ -145,7 +147,11 @@ class ReplayLoader {
 			throw new Error("No replay data available to load.");
 		}
 
-		this.replayData = JSON.parse(fileData) as ReplayData;
+		this.loadReplayData(JSON.parse(fileData) as ReplayData);
+	}
+
+	public loadReplayData(replayData: ReplayData): void {
+		this.replayData = replayData;
 		if (
 			!this.replayData.ticks ||
 			typeof this.replayData.full_tick_amount !== "number"
@@ -189,6 +195,17 @@ class ReplayLoader {
 		console.log(
 			`💫 Replay loaded successfully! ✨ (${this.replayData.misc.team_results[0].name} 🤜 vs 🤛 ${this.replayData.misc.team_results[1].name} for ${totalReplayTicks} ticks)`,
 		);
+	}
+
+	public appendTick(tick: number, tickData: ReplayTick): void {
+		if (tickData && Object.keys(tickData).length > 0) {
+			this.replayData.ticks[String(tick)] = deepClone(tickData);
+		}
+		this.replayData.full_tick_amount = Math.max(
+			this.replayData.full_tick_amount,
+			tick,
+		);
+		totalReplayTicks = this.replayData.full_tick_amount;
 	}
 
 	private applyDiff(state: State, tickData: ReplayTick): void {
@@ -307,6 +324,8 @@ let replayInterval: ReturnType<typeof setInterval> | null = null;
 let currentFilePath: string | null = null;
 let currentCacheInterval = 25;
 let lastEtag: string | null = null;
+let liveSocket: WebSocket | null = null;
+let liveReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 async function resetReplay(reason: string = "reset"): Promise<void> {
 	if (!currentFilePath) {
@@ -333,6 +352,10 @@ export async function setupReplayLoader(
 	cacheInterval = 25,
 	updateInterval = 3000,
 ): Promise<void> {
+	if (liveReconnectTimer) clearTimeout(liveReconnectTimer);
+	liveReconnectTimer = null;
+	liveSocket?.close();
+	liveSocket = null;
 	currentFilePath = filePath;
 	currentCacheInterval = cacheInterval;
 
@@ -394,6 +417,73 @@ export async function setupReplayLoader(
 			console.error("Error checking for updates:", err);
 		}
 	}, updateInterval);
+}
+
+type LiveReplayMessage =
+	| { type: "snapshot"; replay: ReplayData }
+	| { type: "tick"; tick: number; data: ReplayTick }
+	| { type: "complete"; replay: ReplayData };
+
+export async function setupLiveReplayLoader(
+	websocketUrl: string,
+	cacheInterval = 25,
+	followLive = false,
+): Promise<void> {
+	if (replayInterval) clearInterval(replayInterval);
+	replayInterval = null;
+	currentFilePath = null;
+	currentCacheInterval = cacheInterval;
+
+	let receivedInitialSnapshot = false;
+	let resolveInitial: (() => void) | null = null;
+	const initialSnapshot = new Promise<void>((resolve) => {
+		resolveInitial = resolve;
+	});
+
+	const connect = () => {
+		const socket = new WebSocket(websocketUrl);
+		liveSocket = socket;
+		socket.addEventListener("message", (event) => {
+			try {
+				const message = JSON.parse(String(event.data)) as LiveReplayMessage;
+				if (message.type === "snapshot" || message.type === "complete") {
+					const loader = new ReplayLoader(currentCacheInterval);
+					loader.loadReplayData(message.replay);
+					replayLoader = loader;
+					tempStateCache = null;
+					if (!receivedInitialSnapshot) {
+						receivedInitialSnapshot = true;
+						setupRenderer();
+						ensureIcons();
+						updateWinDisplayEmojis();
+						resolveInitial?.();
+					} else {
+						updateTimeRange();
+						updateWinDisplayEmojis();
+					}
+					return;
+				}
+				if (message.type === "tick" && replayLoader) {
+					replayLoader.appendTick(message.tick, message.data);
+					tempStateCache = null;
+					updateTimeRange();
+					if (followLive) startPlayback();
+				}
+			} catch (error) {
+				console.error("Invalid live replay message:", error);
+			}
+		});
+		socket.addEventListener("error", () => {
+			console.warn(`Live replay connection failed: ${websocketUrl}`);
+		});
+		socket.addEventListener("close", () => {
+			if (liveSocket !== socket) return;
+			liveReconnectTimer = setTimeout(connect, 1000);
+		});
+	};
+
+	connect();
+	await initialSnapshot;
 }
 
 let tempStateCache:


### PR DESCRIPTION
## Summary
- Add an optional server WebSocket for live replay snapshots, tick updates, and completion events
- Support `live` visualizer URLs with reconnecting playback and dynamically updated timelines
- Preserve existing replay file playback and document the live replay configuration

## Testing
- Not run (not requested)